### PR TITLE
now with reversible page order, fix for #14

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Launch February 4th 2025
 
 ## Versions
 
+- v0.0.3 - reverse page order
 - v0.0.2 - fix typo, fix octavo fat fold line, turned on rotation functionality
 - v0.0.1 - disable rotation UI as it doesn't work yet
 - v0.0.0 - launch!

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
       upload_blocks: [/*{ pageSelection: String, precedingBlanks: Int , file: File, pdfDoc: PDFLib.PDFDocument } */],
       unified_source: { leftRotDeg: 0, rightRotDeg: 0, marginLeft: 0, marginRight: 0, marginTop: 0, marginBottom: 0, pageCount: 0, pdf_is_valid: false, maxWidth: 0,  maxHeight: 0, is_large_file: false /* _scale100px: Int,  */ }, 
       imposition: { /* name: String, canCustomizeCounts:Boolean, defaultFolioCounts: Int/String, foliosPerSheet: List<Int>, cellCount_l:Int, cellCount_s:Int*/},
-      imposed: { /* sheets: List<List<PageNumber>>, signatures: List<List<PageNumber>>, hasSplitSig: Boolean, requiresCutting: Boolean */ },
+      imposed: { /* sheets: List<List<PageNumber>>, signatures: List<List<PageNumber>>, pageCount: Int, blanks: Int, hasSplitSig: Boolean, requiresCutting: Boolean */ },
       physical: { short_margin: 0, long_margin: 0, scaling: 'fit', placement: 'center' /* display_unit: String */},
       page_orientation: null,
       display_unit: null, // what to show, ex: cm
@@ -113,6 +113,9 @@
       }
     }
     #page_manipulation {
+      #pdf_reverse_order_label {
+        margin-left: 40px;
+      }
       #pdf_marins_example{
         float:right;
         width: auto;
@@ -383,7 +386,7 @@
   <body>
     <main class="container">
       <section id="title">
-        <h1>Villainous Imposer<BR><small id="version_info">v0.0.2</small>[VI]</h1>
+        <h1>Villainous Imposer<BR><small id="version_info">v0.0.3</small>[VI]</h1>
         <details>
           <summary>information & glossary</summary>
           <p>
@@ -480,10 +483,10 @@
           <div id="example_pdf_orientation_page_right" ></div><div id="example_pdf_orientation_spine" ></div><div id="example_pdf_orientation_page_left" ></div>
         </div>
         <br style="float:clear;">
-        <details class="disabled">
+        <details>
           <summary>Explanation</summary>
           <p>
-            This is about how the PDF pages are oriented relative to the spine.<BR>
+            Rotation is about how the PDF pages are oriented relative to the spine.<BR>
             Page <code>A</code> is the 1st page of the completed, closed textblock while <code>B</code> &amp; <code>C</code> are a sample spread (spine in the middle)<BR>
             The rotation of the letters indicate how the pages would be oriented.<BR>
             <mark>In most cases the 1st option is what is desired/expected</mark>, but there are reasons why you might want the others<BR>
@@ -513,6 +516,7 @@
           </script>
         </fieldset>
         </span>
+        <div><label id="pdf_reverse_order_label" for="pdf_reverse_order"><input type="checkbox" role="switch" id="pdf_reverse_order" name="pdf_reverse_order"> reverse PDF order</label></div>
         <br>&nbsp;
       </section>
 

--- a/js/helper.js
+++ b/js/helper.js
@@ -160,6 +160,8 @@ export const form = {
       window.book.imposed.signatures.push([p, p+1, p+1, p]);
       window.book.imposed.sheets.push([p, p+1, p+1, p]);
     }
+    window.book.imposed.pageCount = pageCount + (pageCount % 2)
+    window.book.imposed.blanks = pageCount % 2
     const outputEl = document.getElementById("imposition_folio_calculations")
     outputEl.removeAttribute("style")
     outputEl.innerHTML = "<small>Given "+pageCount+" PDF pages<br> ➥ "+ Math.ceil(pageCount/2)+" sheets</small>"
@@ -169,6 +171,8 @@ export const form = {
     window.book.imposed.signatures = [[[0,0,7,7],[1,1,2,2],[3,3,4,4],[5,5,6,6,]]];
     window.book.imposed.hasSplitSig = false;
     window.book.imposed.requiresCutting = false;
+    window.book.imposed.pageCount = 8
+    window.book.imposed.blanks = 8 - Math.max(8,pageCount)
     const outputEl = document.getElementById("imposition_folio_calculations")
     outputEl.removeAttribute("style")
     outputEl.innerHTML = "<small>Given "+pageCount+" PDF pages<br> ➥ 1 sheet</small>"
@@ -199,6 +203,8 @@ export const form = {
       return;
     }
     this._populateSheets(counts)
+    window.book.imposed.pageCount = window.book.imposed.signatures.map(s => s.length).reduce((a,v) => a+v,0) * 4;
+    window.book.imposed.blanks = window.book.imposed.pageCount - pageCount;
     let s = "<small>"
     const isSuggestion = counts.length == suggested.length && counts.every((x,i) => x == suggested[i])
     const suggestedCounts = (canCustomize && !isSuggestion) ? "<sub>suggested "+suggested.join(", ")+"</sub>" : ""
@@ -209,7 +215,8 @@ export const form = {
       s += "And "+ pageCount + " pages ("+Math.ceil(pageCount/4)+" folios)<br>"
       s += " ➥ "+window.book.imposed.sheets.length+" printed sheets<br>"
       s += " ➥ "+window.book.imposed.signatures.length+" signatures<br>"
-      s += " ➥ "+window.book.imposed.signatures.map(x => x.length).reduce((acc, x) => acc + x, 0) * 4+" pages<br>"
+      s += " ➥ "+window.book.imposed.pageCount+" pages<br>"
+      s += " ➥ "+window.book.imposed.blanks+" blanks @ the end<br>"
       if (window.book.imposed.requiresCutting)
         s += " ✂️ Cutting required to seperate signatures<br>"
       if (window.book.imposed.hasSplitSig)

--- a/js/state_modifiers.js
+++ b/js/state_modifiers.js
@@ -38,6 +38,15 @@ export const unified_source_modifier = {
     const isNumber = function(value) {
       return typeof value === "number" && isFinite(value);
     }
+    const origPageNum = pageNum
+    let reversePageNum = (document.getElementById("pdf_reverse_order").checked) ? window.book.imposed.pageCount - pageNum - 1 : pageNum
+    if (window.book.imposed.blanks > 0) {
+      reversePageNum -= window.book.imposed.blanks
+      if (reversePageNum < 0) {
+        reversePageNum = origPageNum
+      }
+    }
+    pageNum = reversePageNum
     const lookForPage = function(acc, curBlock, block_i) {
       if (!isNumber(acc)) {
         return acc


### PR DESCRIPTION
PDFs can now be reversed 🥳 

also now displaying # of blanks at the end (that pad out final folio)

my reverse logic in `js/state_modifiers.js`'s `_getPdfPageForPageNumber` isn't that clever, but it gets the job done... 🤷‍♀️ 